### PR TITLE
remove forcats and tidyr from Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,6 @@ Suggests:
     BayesFactor,
     poorman,
     energy,
-    forcats,
     ggcorrplot,
     ggplot2,
     ggraph,
@@ -77,7 +76,6 @@ Suggests:
     see,
     spelling,
     testthat (>= 3.0.1),
-    tidyr,
     tidygraph,
     wdm,
     WRS2

--- a/vignettes/types.Rmd
+++ b/vignettes/types.Rmd
@@ -31,13 +31,13 @@ set.seed(333)
 
 
 if (!requireNamespace("see", quietly = TRUE) ||
-  !requireNamespace("tidyr", quietly = TRUE) ||
+  !requireNamespace("datawizard", quietly = TRUE) ||
   !requireNamespace("poorman", quietly = TRUE) ||
   !requireNamespace("ggplot2", quietly = TRUE)) {
   knitr::opts_chunk$set(eval = FALSE)
 } else {
   library(see)
-  library(tidyr)
+  library(datawizard)
   library(poorman)
   library(ggplot2)
 }
@@ -174,7 +174,7 @@ library(correlation)
 library(bayestestR)
 library(see)
 library(ggplot2)
-library(tidyr)
+library(datawizard)
 library(poorman)
 ```
 
@@ -228,12 +228,13 @@ for (r in seq(0, 0.999, length.out = 200)) {
   }
 }
 
-
 data %>%
-  tidyr::pivot_longer(-c(n, r, transformation),
-                      names_to = "Type",
-                      values_to = "Estimation") %>% 
-  mutate(Type = forcats::fct_relevel(Type, "Pearson", "Spearman", "Kendall", "Biweight", "Distance")) %>%
+  datawizard::reshape_longer(
+    select = -c("n", "r", "transformation"),
+    names_to = "Type",
+    values_to = "Estimation"
+  ) %>% 
+  mutate(Type = relevel(as.factor(Type), "Pearson", "Spearman", "Kendall", "Biweight", "Distance")) %>%
   ggplot(aes(x = r, y = Estimation, fill = Type)) +
   geom_smooth(aes(color = Type), method = "loess", alpha = 0) +
   geom_vline(aes(xintercept = 0.5), linetype = "dashed") +
@@ -246,9 +247,11 @@ data %>%
   facet_wrap(~transformation)
 
 model <- data %>%
-  tidyr::pivot_longer(-c(n, r, transformation),
-                      names_to = "Type",
-                      values_to = "Estimation") %>% 
+  datawizard::reshape_longer(
+    select = -c("n", "r", "transformation"),
+    names_to = "Type",
+    values_to = "Estimation"
+  ) %>% 
   lm(r ~ Type / Estimation, data = .) %>%
   parameters::parameters()
 


### PR DESCRIPTION
`{gt}` is needed in tests and I didn't see other packages that are not used in tests / vignettes / source code. Close #240