### PR TITLE
Tests cleanup

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,12 +1,6 @@
-requiet <- function(package) {
-  testthat::skip_if_not_installed(package)
-  suppressPackageStartupMessages(
-    require(package, warn.conflicts = FALSE, character.only = TRUE)
-  )
+skip_if_not_or_load_if_installed <- function(package, minimum_version = NULL) {
+  testthat::skip_if_not_installed(package, minimum_version = minimum_version)
+  suppressMessages(suppressWarnings(suppressPackageStartupMessages(
+    require(package, warn.conflicts = FALSE, character.only = TRUE, quietly = TRUE)
+  )))
 }
-
-# load all hard dependencies
-requiet("bayestestR")
-requiet("insight")
-requiet("datawizard")
-requiet("parameters")

--- a/tests/testthat/test-as.list.R
+++ b/tests/testthat/test-as.list.R
@@ -1,7 +1,7 @@
-requiet("poorman")
-requiet("ggplot2")
-
 test_that("as.list", {
+  skip_if_not_or_load_if_installed("poorman")
+  skip_if_not_or_load_if_installed("ggplot2")
+
   # no groups
   set.seed(123)
   expect_snapshot(as.list(correlation(mtcars)))

--- a/tests/testthat/test-cor_multilevel.R
+++ b/tests/testthat/test-cor_multilevel.R
@@ -1,7 +1,6 @@
-requiet("lme4")
-
 test_that("comparison rmcorr", {
-  requiet("rmcorr")
+  skip_if_not_or_load_if_installed("lme4")
+  skip_if_not_or_load_if_installed("rmcorr")
   set.seed(123)
   rez_rmcorr <- rmcorr::rmcorr(Species, Sepal.Length, Sepal.Width, dataset = iris)
 
@@ -17,6 +16,7 @@ test_that("comparison rmcorr", {
 
 
 test_that("Reductio ad absurdum", {
+  skip_if_not_or_load_if_installed("lme4")
   cormatrix <- matrix(
     c(
       1.0, 0.3, 0.6,

--- a/tests/testthat/test-cor_test.R
+++ b/tests/testthat/test-cor_test.R
@@ -15,51 +15,50 @@ test_that("cor_test kendall", {
 
 
 test_that("cor_test bayesian", {
-  if (requiet("BayesFactor")) {
-    out <- cor_test(iris, "Petal.Length", "Petal.Width", bayesian = TRUE)
-    expect_equal(out$r, 0.9591191, tolerance = 0.01)
+  skip_if_not_or_load_if_installed("BayesFactor")
+  out <- cor_test(iris, "Petal.Length", "Petal.Width", bayesian = TRUE)
+  expect_equal(out$r, 0.9591191, tolerance = 0.01)
+
+  set.seed(123)
+  df_1 <- cor_test(iris, "Petal.Length", "Petal.Width", bayesian = TRUE)
+
+  set.seed(123)
+  df_2 <- cor_test(iris, "Petal.Length", "Petal.Width", method = "auto", bayesian = TRUE)
+  expect_equal(df_1, df_2, tolerance = 0.001)
+
+  out2 <- cor_test(iris, "Petal.Length", "Petal.Width", method = "spearman", bayesian = TRUE)
+  expect_equal(out2$rho, 0.9323004, tolerance = 0.01)
+
+  df <- iris
+  df$Petal.Length2 <- df$Petal.Length
+  out3 <- cor_test(df, "Petal.Length", "Petal.Length2", bayesian = TRUE)
+  expect_equal(out3$rho, 1.000, tolerance = 0.01)
+
+  if (getRversion() >= "3.6") {
+    set.seed(123)
+    out5 <- cor_test(mtcars, "wt", "mpg", method = "shepherd", bayesian = TRUE)
+    expect_equal(out5$rho, -0.7795719, tolerance = 0.01)
 
     set.seed(123)
-    df_1 <- cor_test(iris, "Petal.Length", "Petal.Width", bayesian = TRUE)
-
-    set.seed(123)
-    df_2 <- cor_test(iris, "Petal.Length", "Petal.Width", method = "auto", bayesian = TRUE)
-    expect_equal(df_1, df_2, tolerance = 0.001)
-
-    out2 <- cor_test(iris, "Petal.Length", "Petal.Width", method = "spearman", bayesian = TRUE)
-    expect_equal(out2$rho, 0.9323004, tolerance = 0.01)
-
-    df <- iris
-    df$Petal.Length2 <- df$Petal.Length
-    out3 <- cor_test(df, "Petal.Length", "Petal.Length2", bayesian = TRUE)
-    expect_equal(out3$rho, 1.000, tolerance = 0.01)
-
-    if (getRversion() >= "3.6") {
-      set.seed(123)
-      out5 <- cor_test(mtcars, "wt", "mpg", method = "shepherd", bayesian = TRUE)
-      expect_equal(out5$rho, -0.7795719, tolerance = 0.01)
-
-      set.seed(123)
-      out6 <- cor_test(mtcars, "wt", "mpg", method = "gaussian", bayesian = TRUE)
-      expect_equal(out6$rho, -0.8294838, tolerance = 0.01)
-    }
-
-    # unsupported
-    expect_error(cor_test(mtcars, "wt", "mpg", method = "biserial", bayesian = TRUE))
-    expect_error(cor_test(mtcars, "wt", "mpg", method = "polychoric", bayesian = TRUE))
-    expect_error(cor_test(mtcars, "wt", "mpg", method = "tetrachoric", bayesian = TRUE))
-    expect_error(cor_test(mtcars, "wt", "mpg", method = "biweight", bayesian = TRUE))
-    expect_error(cor_test(mtcars, "wt", "mpg", method = "distance", bayesian = TRUE))
-    expect_error(cor_test(mtcars, "wt", "mpg", method = "percentage", bayesian = TRUE))
-    expect_error(cor_test(mtcars, "wt", "mpg", method = "blomqvist", bayesian = TRUE))
-    expect_error(cor_test(mtcars, "wt", "mpg", method = "hoeffding", bayesian = TRUE))
-    expect_error(cor_test(mtcars, "wt", "mpg", method = "gamma", bayesian = TRUE))
+    out6 <- cor_test(mtcars, "wt", "mpg", method = "gaussian", bayesian = TRUE)
+    expect_equal(out6$rho, -0.8294838, tolerance = 0.01)
   }
+
+  # unsupported
+  expect_error(cor_test(mtcars, "wt", "mpg", method = "biserial", bayesian = TRUE))
+  expect_error(cor_test(mtcars, "wt", "mpg", method = "polychoric", bayesian = TRUE))
+  expect_error(cor_test(mtcars, "wt", "mpg", method = "tetrachoric", bayesian = TRUE))
+  expect_error(cor_test(mtcars, "wt", "mpg", method = "biweight", bayesian = TRUE))
+  expect_error(cor_test(mtcars, "wt", "mpg", method = "distance", bayesian = TRUE))
+  expect_error(cor_test(mtcars, "wt", "mpg", method = "percentage", bayesian = TRUE))
+  expect_error(cor_test(mtcars, "wt", "mpg", method = "blomqvist", bayesian = TRUE))
+  expect_error(cor_test(mtcars, "wt", "mpg", method = "hoeffding", bayesian = TRUE))
+  expect_error(cor_test(mtcars, "wt", "mpg", method = "gamma", bayesian = TRUE))
 })
 
 test_that("cor_test tetrachoric", {
-  skip_if_not_installed("psych")
-  skip_if_not_installed("polycor")
+  skip_if_not_or_load_if_installed("psych")
+  skip_if_not_or_load_if_installed("polycor")
   data <- iris
   data$Sepal.Width_binary <- ifelse(data$Sepal.Width > 3, 1, 0)
   data$Petal.Width_binary <- ifelse(data$Petal.Width > 1.2, 1, 0)
@@ -101,22 +100,21 @@ test_that("cor_test robust", {
 
 test_that("cor_test distance", {
   skip_if(getRversion() < "4.0")
+  skip_if_not_or_load_if_installed("energy")
 
-  if (requiet("energy")) {
-    out <- cor_test(iris, "Petal.Length", "Petal.Width", method = "distance")
-    comparison <- energy::dcorT.test(iris$Petal.Length, iris$Petal.Width)
-    expect_equal(out$r, as.numeric(comparison$estimate), tolerance = 0.001)
-    expect_identical(out$Method, "Distance (Bias Corrected)")
-  }
+  out <- cor_test(iris, "Petal.Length", "Petal.Width", method = "distance")
+  comparison <- energy::dcorT.test(iris$Petal.Length, iris$Petal.Width)
+  expect_equal(out$r, as.numeric(comparison$estimate), tolerance = 0.001)
+  expect_identical(out$Method, "Distance (Bias Corrected)")
 })
 
 
 test_that("cor_test percentage", {
-  if (requiet("WRS2")) {
-    out <- cor_test(iris, "Petal.Length", "Petal.Width", method = "percentage")
-    comparison <- WRS2::pbcor(iris$Petal.Length, iris$Petal.Width)
-    expect_equal(out$r, as.numeric(comparison$cor), tolerance = 0.01)
-  }
+  skip_if_not_or_load_if_installed("WRS2")
+
+  out <- cor_test(iris, "Petal.Length", "Petal.Width", method = "percentage")
+  comparison <- WRS2::pbcor(iris$Petal.Length, iris$Petal.Width)
+  expect_equal(out$r, as.numeric(comparison$cor), tolerance = 0.01)
 })
 
 
@@ -125,33 +123,31 @@ test_that("cor_test shepherd", {
   out <- cor_test(iris, "Petal.Length", "Petal.Width", method = "shepherd")
   expect_equal(out$r, 0.94762, tolerance = 0.01)
 
-  if (requiet("BayesFactor")) {
-    set.seed(333)
-    out2 <- cor_test(iris, "Petal.Length", "Petal.Width", method = "shepherd", bayesian = TRUE)
-    expect_equal(out2$rho, 0.9429992, tolerance = 0.01)
-  }
+  skip_if_not_or_load_if_installed("BayesFactor")
+  set.seed(333)
+  out2 <- cor_test(iris, "Petal.Length", "Petal.Width", method = "shepherd", bayesian = TRUE)
+  expect_equal(out2$rho, 0.9429992, tolerance = 0.01)
 })
 
 
 test_that("cor_test blomqvist", {
-  if (requiet("wdm")) {
-    set.seed(333)
-    out <- cor_test(iris, "Petal.Length", "Petal.Width", method = "blomqvist")
-    expect_equal(out$r, 0.9066667, tolerance = 0.01)
-  }
+  skip_if_not_or_load_if_installed("wdm")
+
+  set.seed(333)
+  out <- cor_test(iris, "Petal.Length", "Petal.Width", method = "blomqvist")
+  expect_equal(out$r, 0.9066667, tolerance = 0.01)
 })
 
 test_that("cor_test hoeffding and somers", {
-  if (requiet("Hmisc")) {
-    set.seed(333)
-    out <- cor_test(iris, "Petal.Length", "Petal.Width", method = "hoeffding")
-    expect_equal(out$r, 0.5629277, tolerance = 0.01)
+  skip_if_not_or_load_if_installed("Hmisc")
+  set.seed(333)
+  out <- cor_test(iris, "Petal.Length", "Petal.Width", method = "hoeffding")
+  expect_equal(out$r, 0.5629277, tolerance = 0.01)
 
-    set.seed(333)
-    df <- data.frame(x = 1:6, y = c(0, 0, 1, 0, 1, 1))
-    out2 <- cor_test(df, "y", "x", method = "somers")
-    expect_equal(out2$Dxy, 0.7777778, tolerance = 0.01)
-  }
+  set.seed(333)
+  df <- data.frame(x = 1:6, y = c(0, 0, 1, 0, 1, 1))
+  out2 <- cor_test(df, "y", "x", method = "somers")
+  expect_equal(out2$Dxy, 0.7777778, tolerance = 0.01)
 })
 
 test_that("cor_test gamma", {
@@ -161,7 +157,8 @@ test_that("cor_test gamma", {
 })
 
 test_that("cor_test gaussian", {
-  requiet("BayesFactor")
+  skip_if_not_or_load_if_installed("BayesFactor")
+
   set.seed(333)
   out <- cor_test(iris, "Petal.Length", "Petal.Width", method = "gaussian")
   expect_equal(out$r, 0.87137, tolerance = 0.01)

--- a/tests/testthat/test-cor_test_na_present.R
+++ b/tests/testthat/test-cor_test_na_present.R
@@ -1,5 +1,5 @@
 test_that("cor_test frequentist", {
-  skip_if_not_installed("ggplot2")
+  skip_if_not_or_load_if_installed("ggplot2")
 
   expect_error(cor_test(ggplot2::msleep, brainwt, sleep_rem))
 
@@ -8,7 +8,7 @@ test_that("cor_test frequentist", {
 })
 
 test_that("cor_test kendall", {
-  skip_if_not_installed("ggplot2")
+  skip_if_not_or_load_if_installed("ggplot2")
 
   out <- cor_test(ggplot2::msleep, "brainwt", "sleep_rem", method = "kendall")
   out2 <- stats::cor.test(ggplot2::msleep$brainwt, ggplot2::msleep$sleep_rem, method = "kendall")
@@ -18,17 +18,17 @@ test_that("cor_test kendall", {
 })
 
 test_that("cor_test bayesian", {
-  if (requiet("BayesFactor")) {
-    set.seed(123)
-    out <- cor_test(ggplot2::msleep, "brainwt", "sleep_rem", bayesian = TRUE)
-    expect_equal(out$r, -0.1947696, tolerance = 0.01)
-  }
+  skip_if_not_or_load_if_installed("BayesFactor")
+
+  set.seed(123)
+  out <- cor_test(ggplot2::msleep, "brainwt", "sleep_rem", bayesian = TRUE)
+  expect_equal(out$r, -0.1947696, tolerance = 0.01)
 })
 
 test_that("cor_test tetrachoric", {
-  skip_if_not_installed("psych")
-  skip_if_not_installed("polycor")
-  skip_if_not_installed("ggplot2")
+  skip_if_not_or_load_if_installed("psych")
+  skip_if_not_or_load_if_installed("polycor")
+  skip_if_not_or_load_if_installed("ggplot2")
 
   data <- ggplot2::msleep
   data$brainwt_binary <- ifelse(data$brainwt > 3, 1, 0)
@@ -51,7 +51,7 @@ test_that("cor_test tetrachoric", {
 
 
 test_that("cor_test robust", {
-  skip_if_not_installed("ggplot2")
+  skip_if_not_or_load_if_installed("ggplot2")
 
   out1 <- cor_test(ggplot2::msleep, "brainwt", "sleep_rem", method = "pearson", ranktransform = TRUE)
   out2 <- cor_test(ggplot2::msleep, "brainwt", "sleep_rem", method = "spearman", ranktransform = FALSE)
@@ -60,9 +60,9 @@ test_that("cor_test robust", {
 
 
 test_that("cor_test distance", {
-  skip_if_not_installed("ggplot2")
-  skip_if_not_installed("energy")
-  skip_if_not_installed("poorman")
+  skip_if_not_or_load_if_installed("ggplot2")
+  skip_if_not_or_load_if_installed("energy")
+  skip_if_not_or_load_if_installed("poorman")
 
   out <- cor_test(ggplot2::msleep, "brainwt", "sleep_rem", method = "distance")
   df <- poorman::filter(ggplot2::msleep, !is.na(brainwt), !is.na(sleep_rem))
@@ -72,8 +72,8 @@ test_that("cor_test distance", {
 
 
 test_that("cor_test percentage", {
-  skip_if_not_installed("ggplot2")
-  skip_if_not_installed("WRS2")
+  skip_if_not_or_load_if_installed("ggplot2")
+  skip_if_not_or_load_if_installed("WRS2")
 
   out <- cor_test(ggplot2::msleep, "brainwt", "sleep_rem", method = "percentage")
   comparison <- WRS2::pbcor(ggplot2::msleep$brainwt, ggplot2::msleep$sleep_rem)
@@ -82,7 +82,7 @@ test_that("cor_test percentage", {
 
 
 test_that("cor_test shepherd", {
-  skip_if_not_installed("ggplot2")
+  skip_if_not_or_load_if_installed("ggplot2")
 
   set.seed(333)
   expect_error(cor_test(ggplot2::msleep, "brainwt", "sleep_rem", method = "shepherd"))
@@ -90,7 +90,7 @@ test_that("cor_test shepherd", {
 
 
 test_that("cor_test blomqvist", {
-  skip_if_not_installed("wdm")
+  skip_if_not_or_load_if_installed("wdm")
 
   set.seed(333)
   out <- cor_test(ggplot2::msleep, "brainwt", "sleep_rem", method = "blomqvist")
@@ -98,7 +98,7 @@ test_that("cor_test blomqvist", {
 })
 
 test_that("cor_test hoeffding", {
-  skip_if_not_installed("Hmisc")
+  skip_if_not_or_load_if_installed("Hmisc")
 
   set.seed(333)
   out <- cor_test(ggplot2::msleep, "brainwt", "sleep_rem", method = "hoeffding")
@@ -106,7 +106,7 @@ test_that("cor_test hoeffding", {
 })
 
 test_that("cor_test gamma", {
-  skip_if_not_installed("ggplot2")
+  skip_if_not_or_load_if_installed("ggplot2")
 
   set.seed(333)
   out <- cor_test(ggplot2::msleep, "brainwt", "sleep_rem", method = "gamma")
@@ -114,13 +114,13 @@ test_that("cor_test gamma", {
 })
 
 test_that("cor_test gaussian", {
-  skip_if_not_installed("ggplot2")
+  skip_if_not_or_load_if_installed("ggplot2")
 
   set.seed(333)
   out <- cor_test(ggplot2::msleep, "brainwt", "sleep_rem", method = "gaussian")
   expect_equal(out$r, -0.3679795, tolerance = 0.01)
 
-  skip_if_not_installed("BayesFactor")
+  skip_if_not_or_load_if_installed("BayesFactor")
   out <- cor_test(ggplot2::msleep, "brainwt", "sleep_rem", method = "gaussian", bayesian = TRUE)
   expect_equal(out$r, -0.3269572, tolerance = 0.01)
 })
@@ -131,7 +131,7 @@ test_that("cor_test gaussian", {
 
 
 test_that("cor_test one-sided p value", {
-  skip_if_not_installed("ggplot2")
+  skip_if_not_or_load_if_installed("ggplot2")
 
   baseline <- cor.test(ggplot2::msleep$brainwt, ggplot2::msleep$sleep_rem, alternative = "greater")
 

--- a/tests/testthat/test-cor_to_pcor.R
+++ b/tests/testthat/test-cor_to_pcor.R
@@ -1,7 +1,7 @@
-requiet("ppcor")
-requiet("Hmisc")
-
 test_that("pcor_to_cor", {
+  skip_if_not_or_load_if_installed("ppcor")
+  skip_if_not_or_load_if_installed("Hmisc")
+
   set.seed(333)
 
   # easycormatrix
@@ -35,6 +35,8 @@ test_that("pcor_to_cor", {
 
 
 test_that("spcor_to_cor", {
+  skip_if_not_or_load_if_installed("ppcor")
+
   set.seed(333)
 
   # easycormatrix

--- a/tests/testthat/test-correlation.R
+++ b/tests/testthat/test-correlation.R
@@ -1,8 +1,8 @@
 test_that("comparison with other packages", {
-  skip_if_not_installed("ppcor")
-  skip_if_not_installed("Hmisc")
-  skip_if_not_installed("lme4")
-  skip_if_not_installed("BayesFactor")
+  skip_if_not_or_load_if_installed("ppcor")
+  skip_if_not_or_load_if_installed("Hmisc")
+  skip_if_not_or_load_if_installed("lme4")
+  skip_if_not_or_load_if_installed("BayesFactor")
 
   set.seed(333)
 
@@ -104,13 +104,16 @@ test_that("comparison with other packages", {
 
 # Size
 test_that("format checks", {
-  skip_if_not_installed("psych")
+  skip_if_not_or_load_if_installed("psych")
 
   out <- correlation(iris, include_factors = TRUE)
   expect_identical(c(nrow(summary(out, redundant = TRUE)), ncol(summary(out, redundant = TRUE))), c(7L, 8L))
   expect_identical(c(nrow(summary(out)), ncol(summary(out))), c(6L, 7L))
 
-  out <- correlation(iris, method = "auto", include_factors = TRUE)
+  expect_message(
+    out <- correlation(iris, method = "auto", include_factors = TRUE),
+    "Check your data"
+  )
   expect_identical(c(nrow(summary(out, redundant = TRUE)), ncol(summary(out, redundant = TRUE))), c(7L, 8L))
   expect_identical(c(nrow(summary(out)), ncol(summary(out))), c(6L, 7L))
 
@@ -123,7 +126,7 @@ test_that("format checks", {
   expect_identical(c(nrow(summary(out)), ncol(summary(out))), c(2L, 3L))
 
   # Grouped
-  skip_if_not_installed("poorman")
+  skip_if_not_or_load_if_installed("poorman")
   library(poorman)
 
   out <- iris %>%
@@ -147,8 +150,8 @@ test_that("format checks", {
   expect_identical(out$Parameter2, c("Sepal.Length", "Sepal.Width"))
 
   # Bayesian full partial
-  skip_if_not_installed("BayesFactor")
-  skip_if_not_installed("lme4")
+  skip_if_not_or_load_if_installed("BayesFactor")
+  skip_if_not_or_load_if_installed("lme4")
 
 
   out <- correlation(
@@ -167,7 +170,7 @@ test_that("format checks", {
 
 test_that("specific types", {
   skip_on_cran()
-  skip_if_not_installed("psych")
+  skip_if_not_or_load_if_installed("psych")
 
   data <- data.frame(
     x = as.ordered(sample(1:5, 20, TRUE)),
@@ -178,8 +181,8 @@ test_that("specific types", {
 })
 
 test_that("correlation doesn't fail when BFs are NA", {
-  skip_if_not_installed("ggplot2")
-  skip_if_not_installed("BayesFactor")
+  skip_if_not_or_load_if_installed("ggplot2")
+  skip_if_not_or_load_if_installed("BayesFactor")
 
   df <- ggplot2::msleep
 
@@ -190,7 +193,7 @@ test_that("correlation doesn't fail when BFs are NA", {
 
 test_that("as.data.frame for correlation output", {
   skip_on_cran()
-  skip_if_not_installed("ggplot2")
+  skip_if_not_or_load_if_installed("ggplot2")
 
   set.seed(123)
   expect_snapshot(as.data.frame(correlation(ggplot2::msleep)))

--- a/tests/testthat/test-display_print_dataframe.R
+++ b/tests/testthat/test-display_print_dataframe.R
@@ -1,7 +1,6 @@
-requiet("gt")
-
 test_that("display and print method works - markdown", {
   skip_on_cran()
+  skip_if_not_or_load_if_installed("gt")
 
   expect_snapshot(print(correlation(iris)))
 
@@ -12,6 +11,7 @@ test_that("display and print method works - markdown", {
 
 test_that("display and print method works - HTML", {
   skip_on_cran()
+  skip_if_not_or_load_if_installed("gt")
 
   expect_snapshot(display(print(correlation(subset(mtcars, select = c("wt", "mpg"))), format = "html")))
 

--- a/tests/testthat/test-display_print_matrix.R
+++ b/tests/testthat/test-display_print_matrix.R
@@ -1,35 +1,32 @@
-if (requiet("gt") && requiet("poorman")) {
-  # display and print method works - markdown -----------------------------
+# display and print method works - markdown -----------------------------
 
-  test_that("display and print method works - markdown", {
-    skip_on_cran()
+test_that("display and print method works - markdown", {
+  skip_on_cran()
+  skip_if_not_or_load_if_installed("gt")
+  skip_if_not_or_load_if_installed("poorman")
+  expect_snapshot(display(summary(correlation(iris))))
+  expect_snapshot(print(summary(correlation(iris))))
+})
 
-    expect_snapshot(display(summary(correlation(iris))))
-    expect_snapshot(print(summary(correlation(iris))))
-  })
+# display and print method works - html -----------------------------
+test_that("display and print method works - html", {
+  skip_on_cran()
+  skip_if_not_or_load_if_installed("gt")
+  skip_if_not_or_load_if_installed("poorman")
+  expect_snapshot(print(summary(correlation(iris)), format = "html"))
+})
 
-
-
-  # display and print method works - html -----------------------------
-
-  test_that("display and print method works - html", {
-    skip_on_cran()
-
-    expect_snapshot(print(summary(correlation(iris)), format = "html"))
-  })
-
-  test_that("as.matrix works", {
+test_that("as.matrix works", {
+  skip_if_not_or_load_if_installed("gt")
+  skip_if_not_or_load_if_installed("poorman")
+  set.seed(123)
+  mat1 <- select(mtcars, am, wt, hp) %>%
+    correlation() %>%
+    as.matrix()
     set.seed(123)
-    mat1 <- select(mtcars, am, wt, hp) %>%
-      correlation() %>%
-      as.matrix()
-
-    set.seed(123)
-    mat2 <- select(mtcars, am, wt, hp) %>%
-      group_by(am) %>%
-      correlation() %>%
-      as.matrix()
-
+  mat2 <- select(mtcars, am, wt, hp) %>%
+    group_by(am) %>%
+    correlation() %>%
+    as.matrix()
     expect_snapshot(list(mat1, mat2))
-  })
-}
+})

--- a/tests/testthat/test-grouped_data2.R
+++ b/tests/testthat/test-grouped_data2.R
@@ -1,4 +1,5 @@
-if (requiet("poorman")) {
+test_that("correlation with grouped data", {
+  skip_if_not_or_load_if_installed("poorman")
   df <- subset(mtcars, select = c("am", "mpg", "wt")) %>% group_by(am)
 
   expect_error(
@@ -14,4 +15,4 @@ if (requiet("poorman")) {
   )
 
   expect_equal(corr_df$r, c(-0.7676554, -0.9089148), tolerance = 0.001)
-}
+})

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -5,7 +5,7 @@ test_that("as.matrix.correlation", {
 })
 
 test_that("summary.correlation - target column", {
-  skip_if_not_installed("ggplot2")
+  skip_if_not_or_load_if_installed("ggplot2")
   expect_snapshot(summary(correlation(ggplot2::msleep), target = "t"))
   expect_snapshot(summary(correlation(ggplot2::msleep), target = "df_error"))
   expect_snapshot(summary(correlation(ggplot2::msleep), target = "p"))

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -22,6 +22,7 @@ test_that("z_fisher works", {
 })
 
 test_that("simulate_simpson works", {
+  skip_if_not_or_load_if_installed("MASS")
   set.seed(123)
   df <- bayestestR::simulate_simpson(n = 100, groups = 5, r = 0.5)
   expect_equal(dim(df), c(500L, 3L))

--- a/tests/testthat/test-selecting_variables.R
+++ b/tests/testthat/test-selecting_variables.R
@@ -1,37 +1,32 @@
 # select specific variables for correlation -----------------------------
 
-if (requiet("poorman")) {
-  test_that("selecting specific variables works", {
-    set.seed(123)
-    df1 <-
-      mtcars %>%
-      correlation(
-        select = c("cyl", "wt"),
-        select2 = c("hp")
-      )
+test_that("selecting specific variables works", {
+  skip_if_not_or_load_if_installed("poorman")
+  set.seed(123)
+  df1 <- mtcars %>%
+    correlation(
+      select = c("cyl", "wt"),
+      select2 = c("hp")
+    )
 
-    set.seed(123)
-    df2 <-
-      mtcars %>%
-      group_by(am) %>%
-      correlation(
-        select = c("cyl", "wt"),
-        select2 = c("hp")
-      )
+  set.seed(123)
+  df2 <- mtcars %>%
+    group_by(am) %>%
+    correlation(
+      select = c("cyl", "wt"),
+      select2 = c("hp")
+    )
 
-    set.seed(123)
-    df3 <-
-      mtcars %>%
-      correlation(select = "wt", select2 = "hp")
+  set.seed(123)
+  df3 <- mtcars %>%
+    correlation(select = "wt", select2 = "hp")
 
-    set.seed(123)
-    df4 <-
-      mtcars %>%
-      correlation(select = c("wt", "hp"))
+  set.seed(123)
+  df4 <- mtcars %>%
+    correlation(select = c("wt", "hp"))
 
-    expect_snapshot(list(df1, df2, df3, df4))
+  expect_snapshot(list(df1, df2, df3, df4))
 
-    expect_equal(df3$r, df4$r, tolerance = 0.001)
-    expect_equal(df3$t, df4$t, tolerance = 0.001)
-  })
-}
+  expect_equal(df3$r, df4$r, tolerance = 0.001)
+  expect_equal(df3$t, df4$t, tolerance = 0.001)
+})


### PR DESCRIPTION
1. Silence messages, cf https://github.com/easystats/easystats/issues/338: there are duplicated messages `"For i = 2 j = 1  A cell entry of 0 was replaced with correct =  0.5.  Check your data!"` in `test-correlation.R`. This is not expected and is reported in https://github.com/easystats/correlation/issues/260

2. Use `skip_if_not_or_load_if_installed()` inside `test_that()` calls, cf https://github.com/easystats/easystats/issues/350

I also see a bunch of warnings but they are already reported in the R CMD check strict so it shouldn't be fixed in this PR.