### PR TITLE
Use new arguments from openxlsx2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -83,7 +83,7 @@ Suggests:
     tidygraph,
     wdm,
     WRS2,
-    openxlsx2
+    openxlsx2 (>= 1.0)
 VignetteBuilder: 
     knitr
 Encoding: UTF-8

--- a/R/cormatrix_to_excel.R
+++ b/R/cormatrix_to_excel.R
@@ -76,133 +76,133 @@ cormatrix_to_excel <- function(data,
 
   # Colours
   gray_style <- openxlsx2::create_dxfs_style(
-    bgFill = style_gray,
+    bg_fill = style_gray,
     font_color = style_black,
-    numFmt = "#.#0 _*_*_*"
+    num_fmt = "#.#0 _*_*_*"
   )
 
   p_style <- openxlsx2::create_dxfs_style(
-    bgFill = "",
+    bg_fill = "",
     font_color = style_black,
-    numFmt = "#.##0 _*_*_*"
+    num_fmt = "#.##0 _*_*_*"
   )
   p_style1 <- openxlsx2::create_dxfs_style(
-    bgFill = style_green1,
+    bg_fill = style_green1,
     font_color = style_black,
-    numFmt = "#.##0 _*_*_*"
+    num_fmt = "#.##0 _*_*_*"
   )
   p_style2 <- openxlsx2::create_dxfs_style(
-    bgFill = style_green2,
+    bg_fill = style_green2,
     font_color = style_black,
-    numFmt = "#.##0 _*_*_*"
+    num_fmt = "#.##0 _*_*_*"
   )
   p_style3 <- openxlsx2::create_dxfs_style(
-    bgFill = style_green3,
+    bg_fill = style_green3,
     font_color = style_black,
-    numFmt = "#.##0 _*_*_*"
+    num_fmt = "#.##0 _*_*_*"
   )
 
   # no star
   no_star <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 _*_*_*",
+    num_fmt = "#.#0 _*_*_*",
     font_color = style_black,
-    bgFill = ""
+    bg_fill = ""
   )
 
   # one star
   one_star_pink <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*_*_*",
+    num_fmt = "#.#0 \\*_*_*",
     font_color = style_black,
-    bgFill = style_pink
+    bg_fill = style_pink
   )
   one_star_peach <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*_*_*",
+    num_fmt = "#.#0 \\*_*_*",
     font_color = style_black,
-    bgFill = style_peach
+    bg_fill = style_peach
   )
   one_star_red <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*_*_*",
+    num_fmt = "#.#0 \\*_*_*",
     font_color = style_black,
-    bgFill = style_red
+    bg_fill = style_red
   )
   one_star_lightblue <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*_*_*",
+    num_fmt = "#.#0 \\*_*_*",
     font_color = style_black,
-    bgFill = style_lightblue
+    bg_fill = style_lightblue
   )
   one_star_midblue <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*_*_*",
+    num_fmt = "#.#0 \\*_*_*",
     font_color = style_black,
-    bgFill = style_midblue
+    bg_fill = style_midblue
   )
   one_star_darkblue <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*_*_*",
+    num_fmt = "#.#0 \\*_*_*",
     font_color = style_black,
-    bgFill = style_darkblue
+    bg_fill = style_darkblue
   )
 
   # two stars
   two_stars_pink <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*\\*_*",
+    num_fmt = "#.#0 \\*\\*_*",
     font_color = style_black,
-    bgFill = style_pink
+    bg_fill = style_pink
   )
   two_stars_peach <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*\\*_*",
+    num_fmt = "#.#0 \\*\\*_*",
     font_color = style_black,
-    bgFill = style_peach
+    bg_fill = style_peach
   )
   two_stars_red <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*\\*_*",
+    num_fmt = "#.#0 \\*\\*_*",
     font_color = style_black,
-    bgFill = style_red
+    bg_fill = style_red
   )
   two_stars_lightblue <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*\\*_*",
+    num_fmt = "#.#0 \\*\\*_*",
     font_color = style_black,
-    bgFill = style_lightblue
+    bg_fill = style_lightblue
   )
   two_stars_midblue <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*\\*_*",
+    num_fmt = "#.#0 \\*\\*_*",
     font_color = style_black,
-    bgFill = style_midblue
+    bg_fill = style_midblue
   )
   two_stars_darkblue <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*\\*_*",
+    num_fmt = "#.#0 \\*\\*_*",
     font_color = style_black,
-    bgFill = style_darkblue
+    bg_fill = style_darkblue
   )
 
   # three stars
   three_stars_pink <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*\\*\\*",
+    num_fmt = "#.#0 \\*\\*\\*",
     font_color = style_black,
-    bgFill = style_pink
+    bg_fill = style_pink
   )
   three_stars_peach <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*\\*\\*",
+    num_fmt = "#.#0 \\*\\*\\*",
     font_color = style_black,
-    bgFill = style_peach
+    bg_fill = style_peach
   )
   three_stars_red <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*\\*\\*",
+    num_fmt = "#.#0 \\*\\*\\*",
     font_color = style_black,
-    bgFill = style_red
+    bg_fill = style_red
   )
   three_stars_lightblue <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*\\*\\*",
+    num_fmt = "#.#0 \\*\\*\\*",
     font_color = style_black,
-    bgFill = style_lightblue
+    bg_fill = style_lightblue
   )
   three_stars_midblue <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*\\*\\*",
+    num_fmt = "#.#0 \\*\\*\\*",
     font_color = style_black,
-    bgFill = style_midblue
+    bg_fill = style_midblue
   )
   three_stars_darkblue <- openxlsx2::create_dxfs_style(
-    numFmt = "#.#0 \\*\\*\\*",
+    num_fmt = "#.#0 \\*\\*\\*",
     font_color = style_black,
-    bgFill = style_darkblue
+    bg_fill = style_darkblue
   )
 
   # create openxlsx2 workbook
@@ -242,45 +242,41 @@ cormatrix_to_excel <- function(data,
 
   # create conditional formatting for the stars (as well as colours as we have no)
   # one star
+  # Compute the cell range for styling
+  dims_fmt <- openxlsx2::wb_dims(cols = all.columns, rows = all.columns)
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 <= .2, r_values!B2 > 0, p_values!B2 < .05)",
     style = "one_star_pink"
   )
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 >= .2, p_values!B2 < .05)",
     style = "one_star_peach"
   )
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 >= .4, p_values!B2 < .05)",
     style = "one_star_red"
   )
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 >= -.2, r_values!B2 < 0, p_values!B2 < .05)",
     style = "one_star_lightblue"
   )
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 <= -.2, p_values!B2 < .05)",
     style = "one_star_midblue"
   )
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 <= -.4, p_values!B2 < .05)",
     style = "one_star_darkblue"
   )
@@ -288,43 +284,37 @@ cormatrix_to_excel <- function(data,
   # two stars
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 <= .2, r_values!B2 > 0, p_values!B2 < .01)",
     style = "two_stars_pink"
   )
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 >= .2, p_values!B2 < .01)",
     style = "two_stars_peach"
   )
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 >= .4, p_values!B2 < .01)",
     style = "two_stars_red"
   )
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 >= -.02, r_values!B2 < 0, p_values!B2 < .01)",
     style = "two_stars_lightblue"
   )
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 <= -.2, p_values!B2 < .01)",
     style = "two_stars_midblue"
   )
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 <= -.4, p_values!B2 < .01)",
     style = "two_stars_darkblue"
   )
@@ -332,43 +322,37 @@ cormatrix_to_excel <- function(data,
   # three stars
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 <= .2, r_values!B2 > 0, p_values!B2 < .001)",
     style = "three_stars_pink"
   )
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 >= .2, p_values!B2 < .001)",
     style = "three_stars_peach"
   )
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 >= .4, p_values!B2 < .001)",
     style = "three_stars_red"
   )
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 >= -.2, r_values!B2 < 0, p_values!B2 < .001)",
     style = "three_stars_lightblue"
   )
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 <= -.2, p_values!B2 < .001)",
     style = "three_stars_midblue"
   )
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 <= -.4, p_values!B2 < .001)",
     style = "three_stars_darkblue"
   )
@@ -376,61 +360,59 @@ cormatrix_to_excel <- function(data,
   # Other formatting
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(r_values!B2 = 1)",
     style = "gray_style"
   )
   wb$add_conditional_formatting(
     "r_values",
-    cols = all.columns,
-    rows = all.columns,
+    dims = dims_fmt,
     rule = "AND(p_values!B2 >= .05)",
     style = "no_star"
   )
 
   # p-values
-  wb$add_conditional_formatting("p_values",
-    cols = all.columns,
-    rows = all.columns,
+  wb$add_conditional_formatting(
+    "p_values",
+    dims = dims_fmt,
     rule = "< 10",
     style = "p_style"
   )
-  wb$add_conditional_formatting("p_values",
-    cols = all.columns,
-    rows = all.columns,
+  wb$add_conditional_formatting(
+    "p_values",
+    dims = dims_fmt,
     rule = "< .05",
     style = "p_style1"
   )
-  wb$add_conditional_formatting("p_values",
-    cols = all.columns,
-    rows = all.columns,
+  wb$add_conditional_formatting(
+    "p_values",
+    dims = dims_fmt,
     rule = "< .01",
     style = "p_style2"
   )
-  wb$add_conditional_formatting("p_values",
-    cols = all.columns,
-    rows = all.columns,
+  wb$add_conditional_formatting(
+    "p_values",
+    dims = dims_fmt,
     rule = "< .001",
     style = "p_style3"
   )
-  wb$add_conditional_formatting("p_values",
-    cols = all.columns,
-    rows = all.columns,
+  wb$add_conditional_formatting(
+    "p_values",
+    dims = dims_fmt,
     rule = "== 0",
     style = "gray_style"
   )
 
   ## Freeze Panes
-  wb$freeze_pane("r_values", firstCol = TRUE, firstRow = TRUE)
-  wb$freeze_pane("p_values", firstCol = TRUE, firstRow = TRUE)
+  wb$freeze_pane("r_values", first_col = TRUE, first_row = TRUE)
+  wb$freeze_pane("p_values", first_col = TRUE, first_row = TRUE)
 
   # Save Excel
   cat(paste0(
     "\n\n [Correlation matrix '", filename,
     ".xlsx' has been saved to working directory (or where specified).]"
   ))
-  openxlsx2::wb_save(wb, path = paste0(filename, ".xlsx"), overwrite = TRUE)
+  openxlsx2::wb_save(wb, file = paste0(filename, ".xlsx"), overwrite = TRUE)
 
   # open in Excel
   openxlsx2::xl_open(paste0(filename, ".xlsx"))


### PR DESCRIPTION
In openxlsx2 0.8, arguments were changed to snake case

https://janmarvin.github.io/openxlsx2/news/index.html#openxlsx2-08

`rows` and `cols` are also deprecated in favour of dims (the cell range)

See details in https://janmarvin.github.io/openxlsx2/news/index.html#breaking-changes-0-8.

The legacy arguments still work, but they be deprecated in a future openxlsx2 version.