### PR TITLE
Fix partial matching 

### DIFF
--- a/R/cor_test_distance.R
+++ b/R/cor_test_distance.R
@@ -12,7 +12,7 @@
       CI_low = rez$CI_low,
       CI_high = rez$CI_high,
       t = rez$t,
-      df_error = rez$df,
+      df_error = rez$df_error,
       p = rez$p,
       Method = "Distance (Bias Corrected)",
       stringsAsFactors = FALSE

--- a/R/cor_text.R
+++ b/R/cor_text.R
@@ -54,7 +54,7 @@ cor_text <- function(x, show_ci = TRUE, show_statistic = TRUE, show_sig = TRUE, 
       out_text <- paste0(
         out_text,
         ", t(",
-        insight::format_value(x$df, protect_integers = TRUE),
+        insight::format_value(x$df_error, protect_integers = TRUE),
         ") = ",
         insight::format_value(x$t)
       )

--- a/tests/testthat/test-cor_test.R
+++ b/tests/testthat/test-cor_test.R
@@ -17,7 +17,7 @@ test_that("cor_test kendall", {
 test_that("cor_test bayesian", {
   skip_if_not_or_load_if_installed("BayesFactor")
   out <- cor_test(iris, "Petal.Length", "Petal.Width", bayesian = TRUE)
-  expect_equal(out$r, 0.9591191, tolerance = 0.01)
+  expect_equal(out$rho, 0.9591191, tolerance = 0.01)
 
   set.seed(123)
   df_1 <- cor_test(iris, "Petal.Length", "Petal.Width", bayesian = TRUE)
@@ -121,7 +121,7 @@ test_that("cor_test percentage", {
 test_that("cor_test shepherd", {
   set.seed(333)
   out <- cor_test(iris, "Petal.Length", "Petal.Width", method = "shepherd")
-  expect_equal(out$r, 0.94762, tolerance = 0.01)
+  expect_equal(out$rho, 0.94762, tolerance = 0.01)
 
   skip_if_not_or_load_if_installed("BayesFactor")
   set.seed(333)
@@ -164,7 +164,7 @@ test_that("cor_test gaussian", {
   expect_equal(out$r, 0.87137, tolerance = 0.01)
 
   out <- cor_test(iris, "Petal.Length", "Petal.Width", method = "gaussian", bayesian = TRUE)
-  expect_equal(out$r, 0.8620878, tolerance = 0.01)
+  expect_equal(out$rho, 0.8620878, tolerance = 0.01)
 })
 
 

--- a/tests/testthat/test-cor_test_na_present.R
+++ b/tests/testthat/test-cor_test_na_present.R
@@ -22,7 +22,7 @@ test_that("cor_test bayesian", {
 
   set.seed(123)
   out <- cor_test(ggplot2::msleep, "brainwt", "sleep_rem", bayesian = TRUE)
-  expect_equal(out$r, -0.1947696, tolerance = 0.01)
+  expect_equal(out$rho, -0.1947696, tolerance = 0.01)
 })
 
 test_that("cor_test tetrachoric", {
@@ -122,7 +122,7 @@ test_that("cor_test gaussian", {
 
   skip_if_not_or_load_if_installed("BayesFactor")
   out <- cor_test(ggplot2::msleep, "brainwt", "sleep_rem", method = "gaussian", bayesian = TRUE)
-  expect_equal(out$r, -0.3269572, tolerance = 0.01)
+  expect_equal(out$rho, -0.3269572, tolerance = 0.01)
 })
 
 

--- a/tests/testthat/test-correlation.R
+++ b/tests/testthat/test-correlation.R
@@ -177,7 +177,7 @@ test_that("specific types", {
     y = as.ordered(sample(letters[1:5], 20, TRUE))
   )
 
-  correlation(data, method = "polychoric")
+  expect_no_error(correlation(data, method = "polychoric"))
 })
 
 test_that("correlation doesn't fail when BFs are NA", {

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -1,7 +1,7 @@
 test_that("cor_to_cov", {
   cor <- cor(iris[1:4])
   cov <- cov(iris[1:4])
-  cov2 <- cor_to_cov(cor, var = sapply(iris[1:4], var))
+  cov2 <- cor_to_cov(cor, variance = sapply(iris[1:4], var))
   expect_equal(max(cov - cov2), 0, tolerance = 0.0001)
 })
 


### PR DESCRIPTION
with 

```r
options(
    warnPartialMatchArgs = TRUE,
    warnPartialMatchDollar = TRUE,
    warnPartialMatchAttr = TRUE
  )
```

to fix CI and make #320 pass

Still failures, but it's cleaner, and unrelated to the changes