### PR TITLE
Add 'missing' arg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: correlation
 Title: Methods for Correlation Analysis
-Version: 0.8.7
+Version: 0.8.7.1
 Authors@R:
     c(person(given = "Dominique",
              family = "Makowski",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# correlation 0.8.xxx
+
+- `correlation()` gains a `use=` argument, similar to `stats::cor(use=)`, for controlling how missing data is dealt with.
+
 # correlation 0.8.7
 
 - The `format()` method for objects of class `easycormatrix` gets a `zap_small`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # correlation 0.8.xxx
 
-- `correlation()` gains a `use=` argument, similar to `stats::cor(use=)`, for controlling how missing data is dealt with.
+- `correlation()` gains a `missing=` argument, similar to `stats::cor(use=)`, for controlling how missing data is handled.
 
 # correlation 0.8.7
 

--- a/R/correlation.R
+++ b/R/correlation.R
@@ -328,10 +328,10 @@ correlation <- function(data,
   missing <- insight::validate_argument(missing, options = c("keep_pairwise", "keep_complete"))
   if (missing == "keep_complete") {
     if (is.null(data2)) {
-      oo <- complete.cases(data)
+      oo <- stats::complete.cases(data)
       data <- data[which(oo), ]
     } else {
-      oo <- complete.cases(cbind(data, data2))
+      oo <- stats::complete.cases(cbind(data, data2))
       data <- data[which(oo), ]
       data2 <- data2[which(oo), ]
     }

--- a/R/correlation.R
+++ b/R/correlation.R
@@ -33,10 +33,10 @@
 #'   [insight::standardize_names()] on the output to get standardized column
 #'   names. This option can also be set globally by running
 #'   `options(easystats.standardize_names = TRUE)`.
-#' @param missing How should missing values be treated? If `"keep.pairwise"`
+#' @param missing How should missing values be treated? If `"keep_pairwise"`
 #'   (default) then the correlation between each pair of variables is computed
 #'   using all complete pairs of observations on those variables. If
-#'   `"keep.complete"` then missing values are handled by case-wise deletion,
+#'   `"keep_complete"` then missing values are handled by case-wise deletion,
 #'   and correlations are computed using only observations with full data (based
 #'   on `data2`/`select`/`select2` when applicable).
 #' @inheritParams cor_test
@@ -253,7 +253,7 @@ correlation <- function(data,
                         select2 = NULL,
                         rename = NULL,
                         method = "pearson",
-                        missing = "keep.pairwise",
+                        missing = "keep_pairwise",
                         p_adjust = "holm",
                         ci = 0.95,
                         bayesian = FALSE,
@@ -325,8 +325,8 @@ correlation <- function(data,
     }
   }
 
-  missing <- insight::validate_argument(missing, options = c("keep.pairwise", "keep.complete"))
-  if (missing == "keep.complete") {
+  missing <- insight::validate_argument(missing, options = c("keep_pairwise", "keep_complete"))
+  if (missing == "keep_complete") {
     if (is.null(data2)) {
       oo <- complete.cases(data)
       data <- data[which(oo), ]

--- a/R/correlation.R
+++ b/R/correlation.R
@@ -333,6 +333,7 @@ correlation <- function(data,
       data <- data[which(oo), ]
     } else {
       oo <- complete.cases(cbind(data, data2))
+      data <- data[which(oo), ]
       data2 <- data2[which(oo), ]
     }
   }

--- a/R/correlation.R
+++ b/R/correlation.R
@@ -398,7 +398,7 @@ correlation <- function(data,
       partial_bayesian = partial_bayesian,
       bayesian_prior = bayesian_prior,
       include_factors = include_factors,
-      use = use
+      missing = missing
     )
   )
 

--- a/R/correlation.R
+++ b/R/correlation.R
@@ -33,6 +33,13 @@
 #'   [insight::standardize_names()] on the output to get standardized column
 #'   names. This option can also be set globally by running
 #'   `options(easystats.standardize_names = TRUE)`.
+#' @param use How should missing values be treated? If `"pairwise.obs"`
+#'   (default) then the correlation between each pair of variables is computed
+#'   using all complete pairs of observations on those variables. If
+#'   `"complete.obs"` then missing values are handled by case-wise deletion, and
+#'   correlations are computed using only observations with full data (based on
+#'   `data2`/`select`/`select2` when applicable).
+#' Should correlations be computed for all available data for each pair description
 #' @inheritParams cor_test
 #'
 #' @details
@@ -247,6 +254,7 @@ correlation <- function(data,
                         select2 = NULL,
                         rename = NULL,
                         method = "pearson",
+                        use = c("pairwise.obs", "complete.obs"),
                         p_adjust = "holm",
                         ci = 0.95,
                         bayesian = FALSE,
@@ -318,6 +326,17 @@ correlation <- function(data,
     }
   }
 
+  use <- match.arg(use, choices = c("pairwise.obs", "complete.obs"))
+  if (use == "complete.obs") {
+    if (is.null(data2)) {
+      oo <- complete.cases(data)
+      data <- data[which(oo), ]
+    } else {
+      oo <- complete.cases(cbind(data, data2))
+      data2 <- data2[which(oo), ]
+    }
+  }
+
   if (inherits(data, "grouped_df")) {
     rez <- .correlation_grouped_df(
       data,
@@ -378,7 +397,8 @@ correlation <- function(data,
       multilevel = multilevel,
       partial_bayesian = partial_bayesian,
       bayesian_prior = bayesian_prior,
-      include_factors = include_factors
+      include_factors = include_factors,
+      use = use
     )
   )
 

--- a/R/correlation.R
+++ b/R/correlation.R
@@ -33,13 +33,12 @@
 #'   [insight::standardize_names()] on the output to get standardized column
 #'   names. This option can also be set globally by running
 #'   `options(easystats.standardize_names = TRUE)`.
-#' @param use How should missing values be treated? If `"pairwise.obs"`
+#' @param missing How should missing values be treated? If `"keep.pairwise"`
 #'   (default) then the correlation between each pair of variables is computed
 #'   using all complete pairs of observations on those variables. If
-#'   `"complete.obs"` then missing values are handled by case-wise deletion, and
-#'   correlations are computed using only observations with full data (based on
-#'   `data2`/`select`/`select2` when applicable).
-#' Should correlations be computed for all available data for each pair description
+#'   `"keep.complete"` then missing values are handled by case-wise deletion,
+#'   and correlations are computed using only observations with full data (based
+#'   on `data2`/`select`/`select2` when applicable).
 #' @inheritParams cor_test
 #'
 #' @details
@@ -254,7 +253,7 @@ correlation <- function(data,
                         select2 = NULL,
                         rename = NULL,
                         method = "pearson",
-                        use = c("pairwise.obs", "complete.obs"),
+                        missing = "keep.pairwise",
                         p_adjust = "holm",
                         ci = 0.95,
                         bayesian = FALSE,
@@ -326,8 +325,8 @@ correlation <- function(data,
     }
   }
 
-  use <- match.arg(use, choices = c("pairwise.obs", "complete.obs"))
-  if (use == "complete.obs") {
+  missing <- insight::validate_argument(missing, options = c("keep.pairwise", "keep.complete"))
+  if (missing == "keep.complete") {
     if (is.null(data2)) {
       oo <- complete.cases(data)
       data <- data[which(oo), ]

--- a/correlation.Rproj
+++ b/correlation.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 5ab51f05-a107-46c8-b998-a2432a78b2ad
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/man/correlation.Rd
+++ b/man/correlation.Rd
@@ -11,7 +11,7 @@ correlation(
   select2 = NULL,
   rename = NULL,
   method = "pearson",
-  use = c("pairwise.obs", "complete.obs"),
+  missing = "keep.pairwise",
   p_adjust = "holm",
   ci = 0.95,
   bayesian = FALSE,
@@ -65,13 +65,12 @@ dichotomous factors involved, point-biserial if one dichotomous and one
 continuous and pearson otherwise). See below the \strong{details} section for a
 description of these indices.}
 
-\item{use}{How should missing values be treated? If \code{"pairwise.obs"}
+\item{missing}{How should missing values be treated? If \code{"keep.pairwise"}
 (default) then the correlation between each pair of variables is computed
 using all complete pairs of observations on those variables. If
-\code{"complete.obs"} then missing values are handled by case-wise deletion, and
-correlations are computed using only observations with full data (based on
-\code{data2}/\code{select}/\code{select2} when applicable).
-Should correlations be computed for all available data for each pair description}
+\code{"keep.complete"} then missing values are handled by case-wise deletion,
+and correlations are computed using only observations with full data (based
+on \code{data2}/\code{select}/\code{select2} when applicable).}
 
 \item{p_adjust}{Correction method for frequentist correlations. Can be one of
 \code{"holm"} (default), \code{"hochberg"}, \code{"hommel"},

--- a/man/correlation.Rd
+++ b/man/correlation.Rd
@@ -11,6 +11,7 @@ correlation(
   select2 = NULL,
   rename = NULL,
   method = "pearson",
+  use = c("pairwise.obs", "complete.obs"),
   p_adjust = "holm",
   ci = 0.95,
   bayesian = FALSE,
@@ -63,6 +64,14 @@ method (polychoric when ordinal factors involved, tetrachoric when
 dichotomous factors involved, point-biserial if one dichotomous and one
 continuous and pearson otherwise). See below the \strong{details} section for a
 description of these indices.}
+
+\item{use}{How should missing values be treated? If \code{"pairwise.obs"}
+(default) then the correlation between each pair of variables is computed
+using all complete pairs of observations on those variables. If
+\code{"complete.obs"} then missing values are handled by case-wise deletion, and
+correlations are computed using only observations with full data (based on
+\code{data2}/\code{select}/\code{select2} when applicable).
+Should correlations be computed for all available data for each pair description}
 
 \item{p_adjust}{Correction method for frequentist correlations. Can be one of
 \code{"holm"} (default), \code{"hochberg"}, \code{"hommel"},

--- a/man/correlation.Rd
+++ b/man/correlation.Rd
@@ -65,10 +65,10 @@ dichotomous factors involved, point-biserial if one dichotomous and one
 continuous and pearson otherwise). See below the \strong{details} section for a
 description of these indices.}
 
-\item{missing}{How should missing values be treated? If \code{"keep.pairwise"}
+\item{missing}{How should missing values be treated? If \code{"keep_pairwise"}
 (default) then the correlation between each pair of variables is computed
 using all complete pairs of observations on those variables. If
-\code{"keep.complete"} then missing values are handled by case-wise deletion,
+\code{"keep_complete"} then missing values are handled by case-wise deletion,
 and correlations are computed using only observations with full data (based
 on \code{data2}/\code{select}/\code{select2} when applicable).}
 

--- a/man/correlation.Rd
+++ b/man/correlation.Rd
@@ -11,7 +11,7 @@ correlation(
   select2 = NULL,
   rename = NULL,
   method = "pearson",
-  missing = "keep.pairwise",
+  missing = "keep_pairwise",
   p_adjust = "holm",
   ci = 0.95,
   bayesian = FALSE,

--- a/tests/testthat/test-correlation.R
+++ b/tests/testthat/test-correlation.R
@@ -225,7 +225,7 @@ test_that("missing values", {
   r_complete <- stats::cor(data[,1:5], use = "complete")
 
   corr_pairwise <- correlation(data[,1:5])
-  corr_complete <- correlation(data[,1:5], use = "complete")
+  corr_complete <- correlation(data[,1:5], missing = "keep.complete")
 
   expect_equal(as.matrix(corr_pairwise), r_pairwise)
   expect_equal(as.matrix(corr_complete), r_complete)
@@ -236,7 +236,7 @@ test_that("missing values", {
   r_complete <- stats::cor(data[,1:2], data[,3:5], use = "complete")
 
   corr_pairwise <- correlation(data[,1:2], data[,3:5])
-  corr_complete <- correlation(data[,1:2], data[,3:5], use = "complete")
+  corr_complete <- correlation(data[,1:2], data[,3:5], missing = "keep.complete")
 
   expect_equal(as.matrix(corr_pairwise), r_pairwise)
   expect_equal(as.matrix(corr_complete), r_complete)

--- a/tests/testthat/test-correlation.R
+++ b/tests/testthat/test-correlation.R
@@ -211,3 +211,33 @@ test_that("correlation output with zap_small", {
   expect_snapshot(summary(r), variant = "windows")
   expect_snapshot(summary(r, zap_small = FALSE), variant = "windows")
 })
+
+
+test_that("missing values", {
+  library(correlation)
+  library(testthat)
+
+  data <- mtcars
+
+  data[1,1] <- NA
+
+  r_pairwise <- stats::cor(data[,1:5], use = "pairwise")
+  r_complete <- stats::cor(data[,1:5], use = "complete")
+
+  corr_pairwise <- correlation(data[,1:5])
+  corr_complete <- correlation(data[,1:5], use = "complete")
+
+  expect_equal(as.matrix(corr_pairwise), r_pairwise)
+  expect_equal(as.matrix(corr_complete), r_complete)
+
+
+
+  r_pairwise <- stats::cor(data[,1:2], data[,3:5], use = "pairwise")
+  r_complete <- stats::cor(data[,1:2], data[,3:5], use = "complete")
+
+  corr_pairwise <- correlation(data[,1:2], data[,3:5])
+  corr_complete <- correlation(data[,1:2], data[,3:5], use = "complete")
+
+  expect_equal(as.matrix(corr_pairwise), r_pairwise)
+  expect_equal(as.matrix(corr_complete), r_complete)
+})

--- a/tests/testthat/test-correlation.R
+++ b/tests/testthat/test-correlation.R
@@ -214,9 +214,6 @@ test_that("correlation output with zap_small", {
 
 
 test_that("missing values", {
-  library(correlation)
-  library(testthat)
-
   data <- mtcars
 
   data[1,1] <- NA
@@ -225,7 +222,7 @@ test_that("missing values", {
   r_complete <- stats::cor(data[,1:5], use = "complete")
 
   corr_pairwise <- correlation(data[,1:5])
-  corr_complete <- correlation(data[,1:5], missing = "keep.complete")
+  corr_complete <- correlation(data[,1:5], missing = "keep_complete")
 
   expect_equal(as.matrix(corr_pairwise), r_pairwise)
   expect_equal(as.matrix(corr_complete), r_complete)
@@ -236,7 +233,7 @@ test_that("missing values", {
   r_complete <- stats::cor(data[,1:2], data[,3:5], use = "complete")
 
   corr_pairwise <- correlation(data[,1:2], data[,3:5])
-  corr_complete <- correlation(data[,1:2], data[,3:5], missing = "keep.complete")
+  corr_complete <- correlation(data[,1:2], data[,3:5], missing = "keep_complete")
 
   expect_equal(as.matrix(corr_pairwise), r_pairwise)
   expect_equal(as.matrix(corr_complete), r_complete)


### PR DESCRIPTION
``` r
library(correlation)

data <- mtcars
data[1,1] <- NA

cor(data[,1:3], use = "pairwise")
#>             mpg        cyl       disp
#> mpg   1.0000000 -0.8521139 -0.8496233
#> cyl  -0.8521139  1.0000000  0.9020329
#> disp -0.8496233  0.9020329  1.0000000
correlation(data[,1:3]) |> as.matrix()
#>             mpg        cyl       disp
#> mpg   1.0000000 -0.8521139 -0.8496233
#> cyl  -0.8521139  1.0000000  0.9020329
#> disp -0.8496233  0.9020329  1.0000000

cor(data[,1:3], use = "complete")
#>             mpg        cyl       disp
#> mpg   1.0000000 -0.8521139 -0.8496233
#> cyl  -0.8521139  1.0000000  0.9051234
#> disp -0.8496233  0.9051234  1.0000000
correlation(data[,1:3], use = "complete") |> as.matrix()
#>             mpg        cyl       disp
#> mpg   1.0000000 -0.8521139 -0.8496233
#> cyl  -0.8521139  1.0000000  0.9051234
#> disp -0.8496233  0.9051234  1.0000000
```

<sup>Created on 2025-04-02 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
