### PR TITLE
Using method = "auto" fails if there is missing data due to the type checking

### DIFF
--- a/R/utils_find_correlationtype.R
+++ b/R/utils_find_correlationtype.R
@@ -57,8 +57,8 @@
     out$is_continuous <- TRUE
   }
 
-  if (all(x %% 1 == 0)) {
-    out$is_count <- TRUE
+  if (any(!is.na(x)) && all(x %% 1 == 0, na.rm = TRUE)) { 
+      out$is_count <- TRUE 
   }
 
   out

--- a/R/utils_find_correlationtype.R
+++ b/R/utils_find_correlationtype.R
@@ -57,8 +57,8 @@
     out$is_continuous <- TRUE
   }
 
-  if (any(!is.na(x)) && all(x %% 1 == 0, na.rm = TRUE)) { 
-      out$is_count <- TRUE 
+  if (any(!is.na(x)) && all(x %% 1 == 0, na.rm = TRUE)) {
+    out$is_count <- TRUE
   }
 
   out

--- a/tests/testthat/test-cor_pairwise_complete_with_NA.R
+++ b/tests/testthat/test-cor_pairwise_complete_with_NA.R
@@ -1,0 +1,17 @@
+test_that("pairwise complete correlation with missing data works", {
+  set.seed(345345)
+  data_set <- data.frame(
+    a = sample(c(NA, 1:5), 1000, replace = TRUE),
+    b = sample(c(NA, 1:5), 1000, replace = TRUE)
+  )
+
+  expected_cor <- cor(data_set, use = "pairwise.complete.obs")
+
+  got_cor <- correlation::correlation(
+    data = data_set,
+    method = "auto",
+    missing = "keep_pairwise"
+  )
+
+  testthat::expect_equal(got_cor$r, expected_cor[1, 2])
+})


### PR DESCRIPTION
The following currently fails:
 
```
correlation::correlation(data = data.frame(a = sample(c(NA, 1:5), 1000, replace = TRUE),
                                           b = sample(c(NA, 1:5), 1000, replace = TRUE)),
                         method = "auto",
                         missing = "keep_pairwise")
```

The issue arises because the utils_find_correlationtype function assumes no missing data in all(x %% 1 == 0). I've replaced this with a basic check that ensures that NAs are ignored.