### PR TITLE
docs: refer to ranktransform instead of the removed robust argument

### DIFF
--- a/R/cor_test.R
+++ b/R/cor_test.R
@@ -9,7 +9,7 @@
 #'   set to `0.95` (`95%` CI).
 #' @param method A character string indicating which correlation coefficient is
 #'   to be used for the test. One of `"pearson"` (default), `"kendall"`,
-#'   `"spearman"` (but see also the `robust` argument), `"biserial"`,
+#'   `"spearman"` (but see also the `ranktransform` argument), `"biserial"`,
 #'   `"polychoric"`, `"tetrachoric"`, `"biweight"`, `"distance"`, `"percentage"`
 #'   (for percentage bend correlation), `"blomqvist"` (for Blomqvist's
 #'   coefficient), `"hoeffding"` (for Hoeffding's D), `"gamma"`, `"gaussian"`
@@ -42,7 +42,7 @@
 #'   estimating the correlation, which is one way of making the analysis more
 #'   resistant to extreme values (outliers). Note that, for instance, a
 #'   Pearson's correlation on rank-transformed data is equivalent to a
-#'   Spearman's rank correlation. Thus, using `robust=TRUE` and
+#'   Spearman's rank correlation. Thus, using `ranktransform=TRUE` and
 #'   `method="spearman"` is redundant. Nonetheless, it is an easy option to
 #'   increase the robustness of the correlation as well as flexible way to
 #'   obtain Bayesian or multilevel Spearman-like rank correlations.

--- a/man/cor_test.Rd
+++ b/man/cor_test.Rd
@@ -31,7 +31,7 @@ cor_test(
 
 \item{method}{A character string indicating which correlation coefficient is
 to be used for the test. One of \code{"pearson"} (default), \code{"kendall"},
-\code{"spearman"} (but see also the \code{robust} argument), \code{"biserial"},
+\code{"spearman"} (but see also the \code{ranktransform} argument), \code{"biserial"},
 \code{"polychoric"}, \code{"tetrachoric"}, \code{"biweight"}, \code{"distance"}, \code{"percentage"}
 (for percentage bend correlation), \code{"blomqvist"} (for Blomqvist's
 coefficient), \code{"hoeffding"} (for Hoeffding's D), \code{"gamma"}, \code{"gaussian"}
@@ -77,7 +77,7 @@ simple regression model.}
 estimating the correlation, which is one way of making the analysis more
 resistant to extreme values (outliers). Note that, for instance, a
 Pearson's correlation on rank-transformed data is equivalent to a
-Spearman's rank correlation. Thus, using \code{robust=TRUE} and
+Spearman's rank correlation. Thus, using \code{ranktransform=TRUE} and
 \code{method="spearman"} is redundant. Nonetheless, it is an easy option to
 increase the robustness of the correlation as well as flexible way to
 obtain Bayesian or multilevel Spearman-like rank correlations.}

--- a/man/cor_to_p.Rd
+++ b/man/cor_to_p.Rd
@@ -19,7 +19,7 @@ set to \code{0.95} (\verb{95\%} CI).}
 
 \item{method}{A character string indicating which correlation coefficient is
 to be used for the test. One of \code{"pearson"} (default), \code{"kendall"},
-\code{"spearman"} (but see also the \code{robust} argument), \code{"biserial"},
+\code{"spearman"} (but see also the \code{ranktransform} argument), \code{"biserial"},
 \code{"polychoric"}, \code{"tetrachoric"}, \code{"biweight"}, \code{"distance"}, \code{"percentage"}
 (for percentage bend correlation), \code{"blomqvist"} (for Blomqvist's
 coefficient), \code{"hoeffding"} (for Hoeffding's D), \code{"gamma"}, \code{"gaussian"}

--- a/man/correlation.Rd
+++ b/man/correlation.Rd
@@ -54,7 +54,7 @@ selected. Ignored if \code{data2} is specified.}
 
 \item{method}{A character string indicating which correlation coefficient is
 to be used for the test. One of \code{"pearson"} (default), \code{"kendall"},
-\code{"spearman"} (but see also the \code{robust} argument), \code{"biserial"},
+\code{"spearman"} (but see also the \code{ranktransform} argument), \code{"biserial"},
 \code{"polychoric"}, \code{"tetrachoric"}, \code{"biweight"}, \code{"distance"}, \code{"percentage"}
 (for percentage bend correlation), \code{"blomqvist"} (for Blomqvist's
 coefficient), \code{"hoeffding"} (for Hoeffding's D), \code{"gamma"}, \code{"gaussian"}
@@ -116,7 +116,7 @@ simple regression model.}
 estimating the correlation, which is one way of making the analysis more
 resistant to extreme values (outliers). Note that, for instance, a
 Pearson's correlation on rank-transformed data is equivalent to a
-Spearman's rank correlation. Thus, using \code{robust=TRUE} and
+Spearman's rank correlation. Thus, using \code{ranktransform=TRUE} and
 \code{method="spearman"} is redundant. Nonetheless, it is an easy option to
 increase the robustness of the correlation as well as flexible way to
 obtain Bayesian or multilevel Spearman-like rank correlations.}


### PR DESCRIPTION
The method and ranktransform docs still pointed readers to a robust argument, which was replaced by ranktransform and winsorize. Closes #344.