### PR TITLE
docs: describe digits, stars and include_significance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # correlation 0.8.9
 
+## Changes
+
+- Documentation was updated and corrected in several places.
+
 ## Bug Fixes
 
 - `cormatrix_to_excel()` now works correctly with openxlsx2 v1.16+. Fixed

--- a/R/display.R
+++ b/R/display.R
@@ -9,9 +9,15 @@
 #'   [`correlation()`][correlation] or its summary.
 #' @param format String, indicating the output format. Currently, only
 #'   `"markdown"` is supported.
-#' @param digits,p_digits To do...
-#' @param stars To do...
-#' @param include_significance To do...
+#' @param digits,p_digits Number of digits used for the correlation
+#'   coefficients and for the significance values. `p_digits` also accepts
+#'   `"apa"`, to format p-values in APA style.
+#' @param stars Logical, if `TRUE`, significance stars are added to the
+#'   coefficients.
+#' @param include_significance Logical, if `TRUE`, the significance values
+#'   themselves (p-values, probability of direction or Bayes factors, depending
+#'   on the correlation) are shown in parentheses next to the coefficients. If
+#'   `FALSE` and `stars = TRUE`, only the stars are shown.
 #' @param ... Currently not used.
 #'
 #' @return A character vector. If `format = "markdown"`, the return value

--- a/man/display.easycormatrix.Rd
+++ b/man/display.easycormatrix.Rd
@@ -47,11 +47,17 @@
 \item{format}{String, indicating the output format. Currently, only
 \code{"markdown"} is supported.}
 
-\item{digits, p_digits}{To do...}
+\item{digits, p_digits}{Number of digits used for the correlation
+coefficients and for the significance values. \code{p_digits} also accepts
+\code{"apa"}, to format p-values in APA style.}
 
-\item{stars}{To do...}
+\item{stars}{Logical, if \code{TRUE}, significance stars are added to the
+coefficients.}
 
-\item{include_significance}{To do...}
+\item{include_significance}{Logical, if \code{TRUE}, the significance values
+themselves (p-values, probability of direction or Bayes factors, depending
+on the correlation) are shown in parentheses next to the coefficients. If
+\code{FALSE} and \code{stars = TRUE}, only the stars are shown.}
 
 \item{...}{Currently not used.}
 }


### PR DESCRIPTION
These parameters of display()/print_md()/print_html() for correlation matrices were documented as 'To do...'. Describe what they actually control, following the code path into format.easycormatrix().