### PR TITLE
Fix three statements in the documentation that do not match the code

### DIFF
--- a/R/correlation.R
+++ b/R/correlation.R
@@ -23,8 +23,7 @@
 #'   selected. Ignored if `data2` is specified.
 #' @param p_adjust Correction method for frequentist correlations. Can be one of
 #'   `"holm"` (default), `"hochberg"`, `"hommel"`,
-#'   `"bonferroni"`, `"BH"`, `"BY"`, `"fdr"`,
-#'   `"somers"` or `"none"`. See
+#'   `"bonferroni"`, `"BH"`, `"BY"`, `"fdr"` or `"none"`. See
 #'   [stats::p.adjust()] for further details.
 #' @param redundant Should the data include redundant rows (where each given
 #'   correlation is repeated two times).

--- a/R/display.R
+++ b/R/display.R
@@ -7,8 +7,8 @@
 #'
 #' @param object,x An object returned by
 #'   [`correlation()`][correlation] or its summary.
-#' @param format String, indicating the output format. Currently, only
-#'   `"markdown"` is supported.
+#' @param format String, indicating the output format. Can be `"markdown"`
+#'   (default) or `"html"`.
 #' @param digits,p_digits To do...
 #' @param stars To do...
 #' @param include_significance To do...

--- a/README.Rmd
+++ b/README.Rmd
@@ -53,7 +53,7 @@ library("correlation")
 
 > **Tip**
 >
-> Instead of `library(bayestestR)`, use `library(easystats)`.
+> Instead of `library(correlation)`, use `library(easystats)`.
 > This will make all features of the  easystats-ecosystem available.
 >
 > To stay updated, use `easystats::install_latest()`.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ library("correlation")
 
 > **Tip**
 >
-> Instead of `library(bayestestR)`, use `library(easystats)`. This will
+> Instead of `library(correlation)`, use `library(easystats)`. This will
 > make all features of the easystats-ecosystem available.
 >
 > To stay updated, use `easystats::install_latest()`.

--- a/man/correlation.Rd
+++ b/man/correlation.Rd
@@ -74,8 +74,7 @@ on \code{data2}/\code{select}/\code{select2} when applicable).}
 
 \item{p_adjust}{Correction method for frequentist correlations. Can be one of
 \code{"holm"} (default), \code{"hochberg"}, \code{"hommel"},
-\code{"bonferroni"}, \code{"BH"}, \code{"BY"}, \code{"fdr"},
-\code{"somers"} or \code{"none"}. See
+\code{"bonferroni"}, \code{"BH"}, \code{"BY"}, \code{"fdr"} or \code{"none"}. See
 \code{\link[stats:p.adjust]{stats::p.adjust()}} for further details.}
 
 \item{ci}{Confidence/Credible Interval level. If \code{"default"}, then it is

--- a/man/display.easycormatrix.Rd
+++ b/man/display.easycormatrix.Rd
@@ -44,8 +44,8 @@
 \item{object, x}{An object returned by
 \code{\link[=correlation]{correlation()}} or its summary.}
 
-\item{format}{String, indicating the output format. Currently, only
-\code{"markdown"} is supported.}
+\item{format}{String, indicating the output format. Can be \code{"markdown"}
+(default) or \code{"html"}.}
 
 \item{digits, p_digits}{To do...}
 


### PR DESCRIPTION
- the README tip named bayestestR instead of correlation
- p_adjust was documented as accepting "somers", which stats::p.adjust() rejects (its methods are holm, hochberg, hommel, bonferroni, BH, BY, fdr and none)
- display() was documented as supporting markdown only, but it dispatches to print_html() for any other format